### PR TITLE
Add authentication tests and configuration improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 *.db-wal
 *.db
 config.ts
+!config/config.ts
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/config/config.ts
+++ b/config/config.ts
@@ -1,0 +1,36 @@
+import 'dotenv/config';
+
+type SameSiteOption = 'strict' | 'lax' | 'none';
+
+function parseNumber(value: string | undefined, fallback: number): number {
+  const parsed = value !== undefined ? Number(value) : NaN;
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined) return fallback;
+  if (value === '1' || value.toLowerCase() === 'true') return true;
+  if (value === '0' || value.toLowerCase() === 'false') return false;
+  return fallback;
+}
+
+function parseSameSite(value: string | undefined, fallback: SameSiteOption): SameSiteOption {
+  if (!value) return fallback;
+  const normalized = value.toLowerCase();
+  if (normalized === 'strict' || normalized === 'lax' || normalized === 'none') {
+    return normalized;
+  }
+  return fallback;
+}
+
+export const PORT = parseNumber(process.env.PORT, 3000);
+export const SECRET_JWT_KEY = process.env.SECRET_JWT_KEY ?? 'change-me-in-prod';
+export const ACCESS_EXPIRES_IN = process.env.ACCESS_EXPIRES_IN ?? '15m';
+export const REFRESH_TTL_SEC = parseNumber(process.env.REFRESH_TTL_SEC, 60 * 60 * 24 * 30);
+export const SALT_ROUNDS = parseNumber(process.env.SALT_ROUNDS, 10);
+
+export const COOKIE_SECURE = parseBoolean(process.env.COOKIE_SECURE, false);
+export const COOKIE_SAMESITE = parseSameSite(process.env.COOKIE_SAMESITE, 'lax');
+export const COOKIE_DOMAIN = process.env.COOKIE_DOMAIN ?? undefined;
+
+export const SQLITE_PATH = process.env.SQLITE_PATH ?? './db/noloop.db';

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "node dist/infra/server.js",
     "db:generate": "drizzle-kit generate --config=./config/drizzle.config.ts",
     "db:migrate": "drizzle-kit migrate --config=./config/drizzle.config.ts",
-    "db:studio": "drizzle-kit studio --config=./config/drizzle.config.ts"
+    "db:studio": "drizzle-kit studio --config=./config/drizzle.config.ts",
+    "test": "NODE_ENV=test SQLITE_PATH=:memory: SALT_ROUNDS=4 SECRET_JWT_KEY=test-secret REFRESH_TTL_SEC=7200 ACCESS_EXPIRES_IN=15m node --test --import tsx ./tests/**/*.test.ts"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "db:generate": "drizzle-kit generate --config=./config/drizzle.config.ts",
     "db:migrate": "drizzle-kit migrate --config=./config/drizzle.config.ts",
     "db:studio": "drizzle-kit studio --config=./config/drizzle.config.ts",
-    "test": "NODE_ENV=test SQLITE_PATH=:memory: SALT_ROUNDS=4 SECRET_JWT_KEY=test-secret REFRESH_TTL_SEC=7200 ACCESS_EXPIRES_IN=15m node --test --import tsx ./tests/**/*.test.ts"
+    "test": "set NODE_ENV=test&& set SQLITE_PATH=:memory:&& set SALT_ROUNDS=4&& set SECRET_JWT_KEY=test-secret&& set REFRESH_TTL_SEC=7200&& set ACCESS_EXPIRES_IN=15m&& node --test --import tsx \"tests/**/*.test.ts\""
   },
   "repository": {
     "type": "git",

--- a/src/infra/db.ts
+++ b/src/infra/db.ts
@@ -1,9 +1,21 @@
+import fs from "node:fs";
+import path from "node:path";
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import * as schema from "../adapters/db/schema.js";
+import { SQLITE_PATH } from "../../config/config.js";
 
 // 1) Conexión a SQLite
-export const sqlite: any = new Database("./db/noloop.db");
+const dbFile = SQLITE_PATH;
+
+if (dbFile !== ":memory:" && dbFile !== "" && !dbFile.startsWith("file:")) {
+  const dir = path.dirname(dbFile);
+  if (dir && dir !== ".") {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+export const sqlite: any = new Database(dbFile);
 
 // 2) Configuración recomendada para concurrencia y durabilidad
 sqlite.pragma("journal_mode = WAL");  // mejor concurrencia en lecturas/escrituras

--- a/src/infra/server.ts
+++ b/src/infra/server.ts
@@ -23,7 +23,7 @@ declare global {
  * 
  ********************************/
 
-const app = express();
+export const app = express();
 
 app.use(helmet());
 app.use(cors({
@@ -51,7 +51,9 @@ app.get('/api/v1/me', requireAuth, (req, res) => res.json({ user: req.user }));
  * 
  ********************************/
 
-const rateLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 10 });
+const rateLimiter: express.RequestHandler = process.env.NODE_ENV === 'test'
+  ? (_req, _res, next) => next()
+  : rateLimit({ windowMs: 15 * 60 * 1000, max: 10 });
 
 app.get('/', (req, res) => {
   const user = req.user ?? null;
@@ -157,6 +159,8 @@ app.use((err: any, _req: express.Request, res: express.Response, _next: express.
   res.status(status).json({ error: err?.message ?? 'Internal Server Error' });
 });
 
-app.listen(PORT, () => {
-  console.log(`[noloop] listening on http://localhost:${PORT}`);
-});
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, () => {
+    console.log(`[noloop] listening on http://localhost:${PORT}`);
+  });
+}

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,402 @@
+import { after, before, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import jwt from 'jsonwebtoken';
+import type { Server } from 'node:http';
+
+import { app } from '../src/infra/server.js';
+import { sqlite } from '../src/infra/db.js';
+import { userRepository } from '../src/adapters/db/userRepo.drizzle.js';
+import { signAccessToken } from '../src/infra/auth.js';
+import { SECRET_JWT_KEY, REFRESH_TTL_SEC } from '../config/config.js';
+
+const strongPassword = 'Stronger#1234';
+
+const schemaSql = `
+DROP TABLE IF EXISTS password_reset_tokens;
+DROP TABLE IF EXISTS refresh_tokens;
+DROP TABLE IF EXISTS users;
+
+CREATE TABLE users (
+  id TEXT PRIMARY KEY,
+  username TEXT NOT NULL UNIQUE,
+  password_hash TEXT NOT NULL,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE TABLE refresh_tokens (
+  jti TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  token_hash TEXT NOT NULL,
+  revoked INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  expires_at INTEGER NOT NULL
+);
+
+CREATE TABLE password_reset_tokens (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  token_hash TEXT NOT NULL,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  expires_at INTEGER NOT NULL,
+  used_at INTEGER
+);
+`;
+
+const truncateSql = `
+DELETE FROM refresh_tokens;
+DELETE FROM password_reset_tokens;
+DELETE FROM users;
+`;
+
+class TestClient {
+  #cookies = new Map<string, string>();
+  constructor(private readonly baseUrl: string) {}
+
+  async request(path: string, options: {
+    method?: string;
+    json?: Record<string, unknown>;
+    headers?: Record<string, string>;
+  } = {}) {
+    const headers = new Headers(options.headers ?? {});
+    let body: string | undefined;
+
+    if (options.json !== undefined) {
+      body = JSON.stringify(options.json);
+      headers.set('content-type', 'application/json');
+    }
+
+    if (this.#cookies.size > 0) {
+      const cookieHeader = Array.from(this.#cookies.entries())
+        .map(([name, value]) => `${name}=${value}`)
+        .join('; ');
+      headers.set('cookie', cookieHeader);
+    }
+
+    const res = await fetch(new URL(path, this.baseUrl), {
+      method: options.method ?? (options.json ? 'POST' : 'GET'),
+      headers,
+      body,
+      redirect: 'manual',
+    });
+
+    const setCookie = res.headers.getSetCookie();
+    if (setCookie.length > 0) {
+      this.#updateCookies(setCookie);
+    }
+
+    let parsedBody: any = null;
+    const contentType = res.headers.get('content-type') ?? '';
+    if (contentType.includes('application/json')) {
+      parsedBody = await res.json();
+    } else if (contentType) {
+      parsedBody = await res.text();
+    }
+
+    return { res, cookies: setCookie, body: parsedBody };
+  }
+
+  getCookieValue(name: string): string | undefined {
+    return this.#cookies.get(name);
+  }
+
+  #updateCookies(cookies: string[]) {
+    for (const raw of cookies) {
+      const [pair, ...attributes] = raw.split(';');
+      const [name, value] = pair.split('=');
+      if (!name) continue;
+
+      const expiresAttr = attributes.find((attr) => attr.trim().toLowerCase().startsWith('expires='));
+      const shouldRemove = value === '' || (expiresAttr && new Date(expiresAttr.split('=')[1]).getTime() <= Date.now());
+      if (shouldRemove) {
+        this.#cookies.delete(name);
+      } else {
+        this.#cookies.set(name, value);
+      }
+    }
+  }
+}
+
+let baseUrl: string;
+let server: Server;
+
+before(async () => {
+  sqlite.exec(schemaSql);
+  server = app.listen(0);
+  await once(server, 'listening');
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+beforeEach(() => {
+  sqlite.exec(truncateSql);
+});
+
+after(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+  sqlite.close();
+});
+
+function getCookie(cookies: string[], name: string): string | undefined {
+  for (const raw of cookies) {
+    const [pair] = raw.split(';');
+    const [cookieName, value] = pair.split('=');
+    if (cookieName === name) return value;
+  }
+  return undefined;
+}
+
+describe('Database connection', () => {
+  it('allows executing basic queries', () => {
+    const row = sqlite.prepare('SELECT 1 as value').get();
+    assert.strictEqual(row.value, 1);
+  });
+});
+
+describe('User repository authentication flow', () => {
+  it('registers and logs in a user with hashed password', async () => {
+    const username = 'user_repo_1';
+    const id = await userRepository.create({ username, password: strongPassword });
+    assert.strictEqual(typeof id, 'string');
+
+    const user = await userRepository.login({ username, password: strongPassword });
+    assert.strictEqual(user.id, id);
+    assert.strictEqual(user.username, username);
+  });
+
+  it('prevents duplicated usernames and invalid credentials', async () => {
+    const username = 'user_repo_2';
+    await userRepository.create({ username, password: strongPassword });
+
+    await assert.rejects(
+      userRepository.create({ username, password: strongPassword }),
+      /ya existe/i,
+    );
+
+    await assert.rejects(
+      userRepository.login({ username, password: 'Wrong#12345' }),
+      /incorrecta/i,
+    );
+  });
+
+  it('rotates refresh tokens securely', async () => {
+    const username = 'user_repo_3';
+    const id = await userRepository.create({ username, password: strongPassword });
+
+    const issued = await userRepository.issueRefresh(id);
+    assert.strictEqual(issued.token.split('.').length, 2);
+    assert.ok(issued.expiresAt > Math.floor(Date.now() / 1000));
+
+    const stored = sqlite.prepare('SELECT token_hash AS tokenHash, revoked FROM refresh_tokens WHERE jti = ?').get(issued.jti);
+    assert.strictEqual(stored.revoked, 0);
+    assert.notStrictEqual(stored.tokenHash, issued.token.split('.')[1]);
+
+    const rotated = await userRepository.rotateRefresh(issued.token);
+    assert.notStrictEqual(rotated.refresh.token, issued.token);
+
+    const old = sqlite.prepare('SELECT revoked FROM refresh_tokens WHERE jti = ?').get(issued.jti);
+    assert.strictEqual(old.revoked, 1);
+  });
+
+  it('revokes refresh tokens individually and in bulk', async () => {
+    const username = 'user_repo_4';
+    const id = await userRepository.create({ username, password: strongPassword });
+
+    const first = await userRepository.issueRefresh(id);
+    const second = await userRepository.issueRefresh(id);
+
+    await userRepository.revokeRefresh(first.token);
+    const storedFirst = sqlite.prepare('SELECT revoked FROM refresh_tokens WHERE jti = ?').get(first.jti);
+    assert.strictEqual(storedFirst.revoked, 1);
+
+    await userRepository.revokeAllRefresh(id);
+    const storedSecond = sqlite.prepare('SELECT revoked FROM refresh_tokens WHERE jti = ?').get(second.jti);
+    assert.strictEqual(storedSecond.revoked, 1);
+  });
+
+  it('validates refresh token input strictly', async () => {
+    await assert.rejects(
+      userRepository.rotateRefresh('invalid'),
+      /invalid refresh token/i,
+    );
+  });
+
+  it('rejects refresh tokens with tampered secrets', async () => {
+    const username = 'user_repo_6';
+    const id = await userRepository.create({ username, password: strongPassword });
+    const { token } = await userRepository.issueRefresh(id);
+    const [jti] = token.split('.');
+
+    await assert.rejects(
+      userRepository.rotateRefresh(`${jti}.tampered`),
+      /invalid refresh token/i,
+    );
+  });
+
+  it('changes passwords and invalidates old credentials', async () => {
+    const username = 'user_repo_5';
+    const id = await userRepository.create({ username, password: strongPassword });
+
+    await userRepository.changePassword({ userId: id, currentPassword: strongPassword, newPassword: 'Different#1234' });
+
+    await assert.rejects(
+      userRepository.login({ username, password: strongPassword }),
+      /incorrecta/i,
+    );
+
+    const user = await userRepository.login({ username, password: 'Different#1234' });
+    assert.strictEqual(user.id, id);
+  });
+});
+
+describe('JWT helpers', () => {
+  it('creates signed tokens with expected payload and expiry', () => {
+    const token = signAccessToken({ id: '123', username: 'jwt-user' });
+    const decoded = jwt.verify(token, SECRET_JWT_KEY) as jwt.JwtPayload;
+    assert.strictEqual(decoded.id, '123');
+    assert.strictEqual(decoded.username, 'jwt-user');
+    assert.strictEqual(typeof decoded.exp, 'number');
+  });
+});
+
+describe('HTTP authentication endpoints', () => {
+  it('registers, logs in and accesses protected routes', async () => {
+    const client = new TestClient(baseUrl);
+    const username = 'http_user_1';
+
+    const register = await client.request('/register', { json: { username, password: strongPassword } });
+    assert.strictEqual(register.res.status, 201);
+
+    const login = await client.request('/login', { json: { username, password: strongPassword } });
+    assert.strictEqual(login.res.status, 200);
+    assert.ok(getCookie(login.cookies, 'access_token'));
+    assert.ok(getCookie(login.cookies, 'refresh_token'));
+
+    const me = await client.request('/api/v1/me');
+    assert.strictEqual(me.res.status, 200);
+    assert.strictEqual(me.body.user.username, username);
+
+    const protectedRes = await client.request('/protected', { method: 'POST' });
+    assert.strictEqual(protectedRes.res.status, 200);
+    assert.strictEqual(protectedRes.body.user.username, username);
+  });
+
+  it('rejects unauthenticated access', async () => {
+    const res = await fetch(new URL('/api/v1/me', baseUrl));
+    assert.strictEqual(res.status, 401);
+  });
+
+  it('refreshes tokens and rotates refresh secrets', async () => {
+    const client = new TestClient(baseUrl);
+    const username = 'http_user_2';
+
+    await client.request('/register', { json: { username, password: strongPassword } });
+    const login = await client.request('/login', { json: { username, password: strongPassword } });
+    const initialRefresh = getCookie(login.cookies, 'refresh_token');
+    assert.ok(initialRefresh);
+
+    const refresh = await client.request('/auth/refresh', { method: 'POST' });
+    assert.strictEqual(refresh.res.status, 200);
+    const newRefresh = getCookie(refresh.cookies, 'refresh_token');
+    assert.ok(newRefresh);
+    assert.notStrictEqual(newRefresh, initialRefresh);
+  });
+
+  it('prevents refresh with invalid or revoked tokens', async () => {
+    const malformed = await fetch(new URL('/auth/refresh', baseUrl), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ refresh_token: 'malformed' }),
+    });
+    assert.strictEqual(malformed.status, 401);
+
+    const client = new TestClient(baseUrl);
+    const username = 'http_user_3';
+    await client.request('/register', { json: { username, password: strongPassword } });
+    const login = await client.request('/login', { json: { username, password: strongPassword } });
+    const refreshToken = getCookie(login.cookies, 'refresh_token');
+    assert.ok(refreshToken);
+
+    await userRepository.revokeRefresh(refreshToken);
+    const revoked = await fetch(new URL('/auth/refresh', baseUrl), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    });
+    assert.strictEqual(revoked.status, 401);
+  });
+
+  it('logs out users and clears cookies', async () => {
+    const client = new TestClient(baseUrl);
+    const username = 'http_user_4';
+
+    await client.request('/register', { json: { username, password: strongPassword } });
+    const login = await client.request('/login', { json: { username, password: strongPassword } });
+    const refreshToken = getCookie(login.cookies, 'refresh_token');
+    assert.ok(refreshToken);
+
+    const logout = await client.request('/auth/logout', { method: 'POST' });
+    assert.strictEqual(logout.res.status, 200);
+    assert.strictEqual(getCookie(logout.cookies, 'access_token'), '');
+    assert.strictEqual(getCookie(logout.cookies, 'refresh_token'), '');
+
+    const refreshAttempt = await fetch(new URL('/auth/refresh', baseUrl), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    });
+    assert.strictEqual(refreshAttempt.status, 401);
+  });
+
+  it('forces re-login after password change', async () => {
+    const client = new TestClient(baseUrl);
+    const username = 'http_user_5';
+
+    await client.request('/register', { json: { username, password: strongPassword } });
+    await client.request('/login', { json: { username, password: strongPassword } });
+
+    const change = await client.request('/change-password', {
+      method: 'POST',
+      json: { currentPassword: strongPassword, newPassword: 'BrandNew#12345' },
+    });
+
+    assert.strictEqual(change.res.status, 200);
+    assert.strictEqual(getCookie(change.cookies, 'access_token'), '');
+    assert.strictEqual(getCookie(change.cookies, 'refresh_token'), '');
+
+    const meAfter = await client.request('/api/v1/me');
+    assert.strictEqual(meAfter.res.status, 401);
+
+    const oldLogin = await client.request('/login', { json: { username, password: strongPassword } });
+    assert.strictEqual(oldLogin.res.status, 401);
+
+    const newLogin = await fetch(new URL('/login', baseUrl), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ username, password: 'BrandNew#12345' }),
+    });
+    assert.strictEqual(newLogin.status, 200);
+  });
+
+  it('rejects forged access tokens', async () => {
+    const forged = jwt.sign({ id: 'attacker', username: 'evil' }, 'wrong-secret');
+    const res = await fetch(new URL('/api/v1/me', baseUrl), {
+      headers: { cookie: `access_token=${forged}` },
+    });
+    assert.strictEqual(res.status, 401);
+  });
+});
+
+it('uses configurable refresh expirations', async () => {
+  const username = 'config_user_1';
+  const id = await userRepository.create({ username, password: strongPassword });
+  const refresh = await userRepository.issueRefresh(id);
+  const now = Math.floor(Date.now() / 1000);
+  assert.ok(refresh.expiresAt > now);
+  assert.ok(refresh.expiresAt - now > 0);
+  assert.ok(refresh.expiresAt - now <= Number(REFRESH_TTL_SEC));
+});


### PR DESCRIPTION
## Summary
- add a centralized configuration module for auth settings and SQLite path overrides
- update the database and server bootstrap to support testing and export the Express app
- add a Node-based integration/unit test suite that exercises authentication and security scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dad8fe0c748326a157706a4891a5a0